### PR TITLE
feat(table-schema-provider/app-provider): pass an error to the render props

### DIFF
--- a/packages/app-provider/src/AppProvider.tsx
+++ b/packages/app-provider/src/AppProvider.tsx
@@ -10,7 +10,7 @@ export type AppProviderProps = ApolloContainerPassedProps & {
   authClient?: ISubscribableAuthClient;
   children:
     | React.ReactNode
-    | ((renderProps: { loading: boolean }) => React.ReactNode);
+    | ((renderProps: { loading: boolean; error?: any }) => React.ReactNode);
 };
 
 type PrefilledApolloContainerProps =

--- a/packages/app-provider/src/AppProvider.tsx
+++ b/packages/app-provider/src/AppProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ISubscribableAuthClient } from '@8base/auth';
 import { AuthProvider } from '@8base-react/auth';
+import { ApolloError } from 'apollo-client';
 import { ApolloContainer, ApolloContainerProps } from './ApolloContainer';
 import { ApolloContainerPassedProps } from './types';
 import { TableSchemaProvider } from '@8base-react/table-schema-provider';
@@ -10,7 +11,10 @@ export type AppProviderProps = ApolloContainerPassedProps & {
   authClient?: ISubscribableAuthClient;
   children:
     | React.ReactNode
-    | ((renderProps: { loading: boolean; error?: any }) => React.ReactNode);
+    | ((renderProps: {
+        loading: boolean;
+        error?: ApolloError;
+      }) => React.ReactNode);
 };
 
 type PrefilledApolloContainerProps =

--- a/packages/table-schema-provider/src/TableSchemaContext.tsx
+++ b/packages/table-schema-provider/src/TableSchemaContext.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { TableSchema, Application } from '@8base/utils';
+import { ApolloError } from 'apollo-client';
 
 export interface ITableSchemaContext {
   tablesList: TableSchema[];
   applicationsList: Application[];
   loading: boolean;
-  error?: any;
+  error?: ApolloError;
 }
 
 const TableSchemaContext = React.createContext<ITableSchemaContext>({

--- a/packages/table-schema-provider/src/TableSchemaContext.tsx
+++ b/packages/table-schema-provider/src/TableSchemaContext.tsx
@@ -5,6 +5,7 @@ export interface ITableSchemaContext {
   tablesList: TableSchema[];
   applicationsList: Application[];
   loading: boolean;
+  error?: any;
 }
 
 const TableSchemaContext = React.createContext<ITableSchemaContext>({

--- a/packages/table-schema-provider/src/TableSchemaProvider.tsx
+++ b/packages/table-schema-provider/src/TableSchemaProvider.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as R from 'ramda';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
+import { ApolloError } from 'apollo-client';
 import { TableSchema, Application } from '@8base/utils';
 
 import { TableSchemaContext } from './TableSchemaContext';
@@ -243,7 +244,7 @@ type TableSchemaProviderProps =
       children: React.ReactNode;
     } & TableSchemaProviderCommonProps)
   | ({
-      children: (props: { loading: boolean; error?: any }) => React.ReactNode;
+      children: (props: { loading: boolean; error?: ApolloError }) => React.ReactNode;
     } & TableSchemaProviderCommonProps);
 
 /**
@@ -251,7 +252,7 @@ type TableSchemaProviderProps =
  * @property {Function} children Children of the provider. Could be either react node or function with loading state.
  */
 class TableSchemaProvider extends React.Component<TableSchemaProviderProps> {
-  public renderChildren = (args: { loading: boolean; error?: any }) => {
+  public renderChildren = (args: { loading: boolean; error?: ApolloError }) => {
     const { children } = this.props;
 
     if (typeof children === 'function') {
@@ -262,7 +263,7 @@ class TableSchemaProvider extends React.Component<TableSchemaProviderProps> {
   };
 
   public renderContent = (
-    { data, loading, error }: { data?: any; loading: boolean; error?: any } = { loading: false },
+    { data, loading, error }: { data?: any; loading: boolean; error?: ApolloError } = { loading: false },
   ) => {
     return (
       <TableSchemaContext.Provider

--- a/packages/table-schema-provider/src/TableSchemaProvider.tsx
+++ b/packages/table-schema-provider/src/TableSchemaProvider.tsx
@@ -243,7 +243,7 @@ type TableSchemaProviderProps =
       children: React.ReactNode;
     } & TableSchemaProviderCommonProps)
   | ({
-      children: (props: { loading: boolean }) => React.ReactNode;
+      children: (props: { loading: boolean; error?: any }) => React.ReactNode;
     } & TableSchemaProviderCommonProps);
 
 /**
@@ -251,7 +251,7 @@ type TableSchemaProviderProps =
  * @property {Function} children Children of the provider. Could be either react node or function with loading state.
  */
 class TableSchemaProvider extends React.Component<TableSchemaProviderProps> {
-  public renderChildren = (args: { loading: boolean }) => {
+  public renderChildren = (args: { loading: boolean; error?: any }) => {
     const { children } = this.props;
 
     if (typeof children === 'function') {
@@ -261,16 +261,19 @@ class TableSchemaProvider extends React.Component<TableSchemaProviderProps> {
     return children;
   };
 
-  public renderContent = ({ data, loading }: { data?: any; loading: boolean } = { loading: false }) => {
+  public renderContent = (
+    { data, loading, error }: { data?: any; loading: boolean; error?: any } = { loading: false },
+  ) => {
     return (
       <TableSchemaContext.Provider
         value={{
           tablesList: R.pathOr([], ['tablesList', 'items'], data),
           applicationsList: R.pathOr([], ['applicationsList', 'items'], data),
           loading,
+          error,
         }}
       >
-        {this.renderChildren({ loading })}
+        {this.renderChildren({ loading, error })}
       </TableSchemaContext.Provider>
     );
   };

--- a/packages/table-schema-provider/src/useApplicationsList.ts
+++ b/packages/table-schema-provider/src/useApplicationsList.ts
@@ -1,11 +1,12 @@
 import { useTableSchema } from './useTableSchema';
 
 function useApplicationsList() {
-  const { applicationsList, loading } = useTableSchema();
+  const { applicationsList, loading, error } = useTableSchema();
 
   return {
     applicationsList,
     loading,
+    error,
   };
 }
 

--- a/packages/table-schema-provider/src/useTableSchema.ts
+++ b/packages/table-schema-provider/src/useTableSchema.ts
@@ -3,12 +3,13 @@ import { useContext } from 'react';
 import { TableSchemaContext } from './TableSchemaContext';
 
 function useTableSchema() {
-  const { tablesList, applicationsList, loading } = useContext(TableSchemaContext);
+  const { tablesList, applicationsList, loading, error } = useContext(TableSchemaContext);
 
   return {
     tablesList,
     applicationsList,
     loading,
+    error,
   };
 }
 

--- a/packages/table-schema-provider/src/useTablesList.ts
+++ b/packages/table-schema-provider/src/useTablesList.ts
@@ -1,11 +1,12 @@
 import { useTableSchema } from './useTableSchema';
 
 function useTablesList() {
-  const { tablesList, loading } = useTableSchema();
+  const { tablesList, loading, error } = useTableSchema();
 
   return {
     tablesList,
     loading,
+    error,
   };
 }
 


### PR DESCRIPTION
If I get an error of `TABLES_SCHEMA_QUERY` I will be able to handle errors and show user understandable message and I wouldn't have to look for the first query in my app and handle it's error.

I hadn't found a `type Error`  in 8base packages so I just set type of an error as `any`.